### PR TITLE
Treat SIGPIPE (exit code 141) as a success

### DIFF
--- a/has
+++ b/has
@@ -125,7 +125,7 @@ __detect(){
     echo ${FAIL} ${command}
     KO=$(($KO+1))
 
-  elif [ ${status} -eq 0 ]; then      ## successfully executed
+  elif [ ${status} -eq 0 ] || [ ${status} -eq 141 ]; then      ## successfully executed
 
     echo ${PASS} ${command} ${version}
     OK=$(($OK+1))


### PR DESCRIPTION
If SIGPIPE is received, it doesn't mean that we didn't manage to extract
the version; this change should fix this issue.

This should resolve #18.