### PR TITLE
Freshen Makefile and update README.md 

### DIFF
--- a/.hastest.bats
+++ b/.hastest.bats
@@ -48,8 +48,8 @@ teardown() {
 @test "make update runs git fetch" {
   cd "${BATS_TEST_DIRNAME}"
   run make update
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" =~ "git fetch --verbose" ]
+  [[ "$status" -eq 0 ]]
+  [[ "${lines[@]}" =~ "git fetch --verbose" ]]
 }
 
 @test "has prints help" {

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -4,7 +4,7 @@ INSTALL_DIR=
 
 ## We need to create a new directory so that .hasrc file in the root does not get read by the `has` instance under test
 setup() {
-  export BATS_TEST_TMPDIR="$BATS_TMPDIR/tmp-for-test"
+  export BATS_TEST_TMPDIR="$w/tmp-for-test"
   mkdir -p "$BATS_TEST_TMPDIR"
   cp -f has "$BATS_TEST_TMPDIR"
   cd "$BATS_TEST_TMPDIR"
@@ -48,7 +48,7 @@ teardown() {
   cd "${BATS_TEST_DIRNAME}"
   run make update
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" == "git pull" ]
+ # [ "${lines[0]}" == "git pull" ]
 }
 
 @test "has prints help" {
@@ -81,7 +81,7 @@ teardown() {
 }
 
 @test "status code reflects number of failed commands" {
-  HAS_ALLOW_UNSAFE=y run bash has foobar bc git barbaz
+  b  run bash has foobar bc git barbaz
 
   [[ "$status" -eq 2 ]]
   [[ "$(echo "${output}" | grep "✘" | grep "foobar")" ]]

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -1,10 +1,11 @@
 #!/usr/bin/env bats
 
 INSTALL_DIR=
+BATS_TMPDIR=${BATS_TMPDIR:-/tmp}
 
 ## We need to create a new directory so that .hasrc file in the root does not get read by the `has` instance under test
 setup() {
-  export BATS_TEST_TMPDIR="$w/tmp-for-test"
+  export BATS_TEST_TMPDIR="$BATS_TMPDIR/tmp-for-test"
   mkdir -p "$BATS_TEST_TMPDIR"
   cp -f has "$BATS_TEST_TMPDIR"
   cd "$BATS_TEST_TMPDIR"
@@ -33,7 +34,7 @@ teardown() {
 }
 
 @test "..even if has is missing from directory" {
-  INSTALL_DIR="${BATS_TEST_TMPDIR}/local"
+  INSTALL_DIR="${BATS_TEST_TMPDIR}/system_local"
   cd "${BATS_TEST_DIRNAME}"
   mv has has-been
   run make PREFIX="${INSTALL_DIR}" install
@@ -48,7 +49,7 @@ teardown() {
   cd "${BATS_TEST_DIRNAME}"
   run make update
   [ "$status" -eq 0 ]
- # [ "${lines[0]}" == "git pull" ]
+  [ "${lines[0]}" == "git fetch --verbose" ]
 }
 
 @test "has prints help" {
@@ -58,7 +59,6 @@ teardown() {
   [[ "$(echo "${output}" | grep "USAGE:")" ]]
   [[ "$(echo "${output}" | grep "EXAMPLE:")" ]]
 }
-
 @test "works with single command check" {
   run bash has git
 
@@ -81,7 +81,7 @@ teardown() {
 }
 
 @test "status code reflects number of failed commands" {
-  b  run bash has foobar bc git barbaz
+  HAS_ALLOW_UNSAFE=y run bash has foobar bc git barbaz
 
   [[ "$status" -eq 2 ]]
   [[ "$(echo "${output}" | grep "✘" | grep "foobar")" ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: bash
 
 before_install:
-  - sudo add-apt-repository ppa:duggan/bats --yes
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq bats
+  - git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+  - mkdir -p /tmp/local
+  - bash /tmp/bats-core/install.sh /tmp/local
+  - export PATH=$PATH:/tmp/local/bin
 install:
   - sudo apt-get install -qq bc
 script:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install: has
 	install -vD -m 0755 has $(DESTDIR)$(PREFIX)/bin/has
 
 update: has
-	git pull
+	git fetch --verbose
 
 uninstall:
 	rm -f /usr/local/bin/has

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
+# Makefile for has
+# https://github.com/kdabir/has
+
+# PREFIX is an environment variable.
+# Use default value if not set.
+ifeq ($(PREFIX),)
+	PREFIX := /usr/local
+endif
+
 test:
 	bats .hastest.bats
 
-install:
-	cp has /usr/local/bin/has
+has:
+	git checkout -- has
+
+install: has
+	install -vD -m 0755 has $(DESTDIR)$(PREFIX)/bin/has
+
+update: has
+	git pull
 
 uninstall:
 	rm -f /usr/local/bin/has
+
+.PHONY: test install uninstall update

--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,28 @@ test : has
 	bats .hastest.bats
 
 has :
+	# ensure 'has' in repo
 	git checkout --force -- has
 
 install : has
-	install -vD -m 0755 has $(DESTDIR)$(PREFIX)/bin/has
+	# install 'has' in specified directory
+	chmod 755 has && \
+	mkdir --verbose --parents $(DESTDIR)$(PREFIX)/bin && \
+	cp --verbose --update has $(DESTDIR)$(PREFIX)/bin/has
 
 # update: has
 update : update-fetch has
 
 update-fetch : update-force
+	# update repo from upstream
 	git fetch --verbose --force
 
 update-force :
-	rm -f has
+	# remove local repo 'has' to force update
+	rm --force has
 
 uninstall :
-	rm -f /usr/local/bin/has
+	rm --force /usr/local/bin/has
 
 .PHONY: test install uninstall update
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cd has
 make PREFIX=$HOME/.local install
 ```
 
-To update just do a `git pull` or `make update` followed by the appropriate `make install` command.
+To update just do a `git fetch` or `make update` followed by the appropriate `make install` command.
 
 ### Downloading to a file
 
@@ -162,6 +162,6 @@ On machines that don't even have `has` installed, your project's `.hasrc` is hon
 If you are contributing a feature, please ensure to check current tests. Add test cases for your feature. Tests are
 executed using the excellent [bats](https://github.com/bats-core/bats-core) testing framework. Add tests and run `make test`
 
-Raise the PR and make sure the tests pass on [Travis-CI](https://travis-ci.org/kdabir/has).
+Raise the PR and **make sure the tests pass** on [Travis-CI](https://travis-ci.org/kdabir/has).
 
 ### ♥

--- a/README.md
+++ b/README.md
@@ -1,93 +1,115 @@
 # has
 
-`has` checks presence of various command line tools on the PATH and reports their installed version. 
+`has` checks presence of various command line tools on the PATH and reports their installed version.
 
 [![Build Status](https://travis-ci.org/kdabir/has.svg?branch=master)](https://travis-ci.org/kdabir/has)
 [![Open Source Helpers](https://www.codetriage.com/kdabir/has/badges/users.svg)](https://www.codetriage.com/kdabir/has)
 
-
 [![demo](demo.svg)](demo.svg)
-
 
 ## How ?
 
-[Install](#installing) the `has` script. There is no dependency apart from `bash` itself 
+[Install](#installing) the `has` script. There is no dependency apart from `bash` itself.
 
-    $ has node npm java git gradle 
-    ✔ node 8.2.1
-    ✔ npm 5.3.0
-    ✔ java 1.8.0
-    ✔ git 2.14.1
-    ✔ gradle 4.0.1
+```console
+$ has node npm java git gradle
+✔ node 8.2.1
+✔ npm 5.3.0
+✔ java 1.8.0
+✔ git 2.14.1
+✔ gradle 4.0.1
+```
 
-If everything is good `has` exits with status code `0`. The status code 
-reflects number of commands **not found** on your path.  
+If everything is good `has` exits with status code `0`. The status code reflects number of commands **not found** on your path.
 
-    $ has node go javac
-    ✔ node 8.2.1
-    ✔ go 1.8.3
-    ✘ javac
+```console
+$ has node go javac
+✔ node 8.2.1
+✔ go 1.8.3
+✘ javac
+```
 
 And echo the status:
 
-    $ echo $?
-    1
-
+```console
+$ echo $?
+1
+```
 
 ## Installing
 
 `has` is a single bash script that does it all. Just [download](https://raw.githubusercontent.com/kdabir/has/master/has) the script and make it available on your `$PATH`. However, to make it even simpler, just follow *one* of these methods.
 
-
 ### Cloning the Repo
 
-Just execute the following command in terminal, it clones has repo and install it in your path
+Just execute the following command in a terminal: it clones `has` repo and installs it into your path.
 
-    git clone https://github.com/kdabir/has.git && cd has && make install
+```bash
+git clone https://github.com/kdabir/has.git && cd has && sudo make install
+```
 
-To update just do a `git pull` and `make install`.
+For a non-root installation:
+
+```bash
+git clone https://github.com/kdabir/has.git
+cd has
+make PREFIX=$HOME/.local install
+```
+
+To update just do a `git pull` or `make update` followed by the appropriate `make install` command.
 
 ### Downloading to a file
 
-    curl -sL https://git.io/_has > /usr/local/bin/has
+```bash
+curl -sL https://git.io/_has > /usr/local/bin/has
+```
 
-This command is safe to be called multiple times as well. (to update `has`)
+```bash
+curl -sL https://git.io/_has | sudo tee /usr/local/bin/has >/dev/null
+```
 
-### Running directly off the internet
+These commands are safe to be called multiple times as well (to update `has`)
 
-If you are lazy, you can run `has` directly off the internet as well:
+### Running directly off the Internet
 
-    curl -sL https://git.io/_has | bash -s git node npm
-    ✔ git 2.14.1
-    ✔ node 8.2.1
-    ✔ npm 5.3.0
+If you are lazy, you can run `has` directly off the Internet as well:
 
+```console
+curl -sL https://git.io/_has | bash -s git node npm
+✔ git 2.17.1
+✔ node 11.11.0
+✔ npm 6.7.0
+```
 
-**ProTip**: if that's too much of typing every time, setup an alias in your `.bashrc`/`.zshrc` file:
-    
-    alias has="curl -sL https://git.io/_has | bash -s"
+**ProTip**: if that's too much typing every time, setup an alias in your `.bashrc`/`.zshrc` file:
+
+```.bashrc
+alias has="curl -sL https://git.io/_has | bash -s"
+```
 
 And use it
 
-    $ has git
-    ✔ git 2.14.1
+```console
+$ has git
+✔ git 2.17.1
+$ type has
+has is aliased to `curl -sL https://git.io/_has | bash -s'
+```
 
 ## Command not understood by has?
 
 Let's say `$ has foobar` returns `foobar not understood`, because `has` may not have whitelisted `foobar`.
 
-In such cases, pass `HAS_ALLOW_UNSAFE=y has foobar`. This is should still check for existance of `foobar` and tries to detect version as well.
-
+In such cases, pass `HAS_ALLOW_UNSAFE=y has foobar`. This should still check for existance of `foobar` and tries to detect version as well.
 
 ## The `.hasrc` file
 
-`has` looks for `.hasrc` file in the directory from where `has` command is issued. This file can contain commands that `has` 
+`has` looks for `.hasrc` file in the directory from where `has` command is issued. This file can contain commands that `has`
 will check for. List one command per line. Lines starting with `#` are treated as comments.
-
 
 Following is example of `.hasrc` file:
 
-```
+```hs
 # tools
 git
 curl
@@ -95,22 +117,22 @@ curl
 # interpreters
 ruby
 node
-``` 
-
-When `has` is run in dir containing this file, it produces:
-
 ```
+
+When `has` is run in directory containing this file, it produces:
+
+```console
 $ has
 ✔ git 2.19.1
 ✔ curl 7.54.0
 ✔ ruby 2.3.1
 ✔ node 10.7.0
-``` 
+```
 
 Also, CLI arguments passed to `has` are additive to `.hasrc` file. For example, in the same dir, if the following command is fired,
-`has` checks for both commands passed from cli args and provided in `.hasrc` file.  
+`has` checks for both commands passed from cli args and provided in `.hasrc` file.
 
-```
+```bash
 $ has java
 ✔ java 11.0.1
 ✔ git 2.19.1
@@ -119,31 +141,27 @@ $ has java
 ✔ node 10.7.0
 ```
 
-
 **Pro Tip**: commit `.hasrc` file in root of your project. This can work as a quick check for confirming presence all command
 line tools required to build and run your project.
 
-On machines that don't even have `has` installed, your project's `.hasrc` is honored by this command: 
+On machines that don't even have `has` installed, your project's `.hasrc` is honored by this command:
 
-`curl -sL https://git.io/_has | bash -s` 
+`curl -sL https://git.io/_has | bash -s`
 
-> take a look at [.hasrc](https://github.com/kdabir/has/blob/master/.hasrc) file of this repo
-
+> take a look at [.hasrc](https://github.com/kdabir/has/blob/master/.hasrc) file for this repo.
 
 ## Contributing
 
-
-1. Star the repo, tweet about it, spread the word 
+1. Star the repo, tweet about it, spread the word
 2. Update the documentation (i.e. the README file)
 3. Adding support for more commands
 4. Adding more features to `has`
-
 
 ## Adding Features
 
 If you are contributing a feature, please ensure to check current tests. Add test cases for your feature. Tests are
 executed using the excellent [bats](https://github.com/bats-core/bats-core) testing framework. Add tests and run `make test`
-   
+
 Raise the PR and make sure the tests pass on [Travis-CI](https://travis-ci.org/kdabir/has).
 
-#### ♥
+### ♥

--- a/has
+++ b/has
@@ -19,7 +19,6 @@ REGEX_SIMPLE_VERSION="([[:digit:]]+\.?){2,3}"
 ## RC file can contain commands to be tested
 RC_FILE=".hasrc"
 
-
 # try to extract version by executing $1 with $2 arg
 __dynamic_detect(){
   cmd=$1
@@ -77,7 +76,7 @@ __detect(){
     vim|emacs|nano|subl)    __dynamic_detect--version ${command} ;;
     bats|tree|ack|autojump) __dynamic_detect--version ${command} ;;
     jq|ag|brew)             __dynamic_detect--version ${command} ;;
-    
+
     R)                      __dynamic_detect--version ${command} ;;
     node|npm|yarn)          __dynamic_detect--version ${command} ;;
     grunt|brunch)           __dynamic_detect--version ${command} ;;

--- a/has
+++ b/has
@@ -173,7 +173,7 @@ fi
 if [[ -z "${HASRC}" ]] && [ "$#" -eq 0 ]; then
   # print help
   BINARY_NAME="has"
-  VERSION="v1.4.1"
+  VERSION="v1.4.0"
   printf "${BINARY_NAME} ${VERSION}\n"
   printf "USAGE:    ${BINARY_NAME} <command-names>..\n"
   printf "EXAMPLE:  ${BINARY_NAME} git curl node\n\n"


### PR DESCRIPTION
# Freshen Makefile and update README.md

## README.md

- [x] Add `sudo` to revelvant commands
- [x] Use named languages (bash) in fenced codeblocks
- [x] Use `console` in fenced codeblocks for command output

## Makefile

### `install` target

- [x] Use `install` with permissions set

The permissions on `has` were 777 from `git clone`.

- [x] Add option to use $PREFIX

What if I don't want to install to /usr/local/bin?

`make PREFIX=$HOME/.local install` now works.

### `update` target

- [x] Add `update` target for `git fetch`
- [x] Include .PHONY targets

## tests

- [x] Add tests for Makefile changes
- [x] Uses `bats` variables for directories

- ✓ make install creates a valid installation
- ✓ ..even if has is missing from directory
- ✓ make update runs git fetch
