### PR TITLE
Linting with shellcheck

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,19 +1,23 @@
 # http://editorconfig.org/
-
 root = true
 
 [*]
 indent_style = space
-indent_size = 2
-
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.{sh,bash,bats}]
+indent_size = 2
+indent_style = space
+
+# Markdown
 [*.md]
+indent_size = 4
 trim_trailing_whitespace = false
 
+# Makefiles always use tabs for indentation
 [{Makefile, makefile}]
 indent_style = tab
 indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
-* text=auto
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+*           text=auto           eol=lf
+#
+# The above will handle all files NOT found below
+#
+*.sh        text diff=sh        eol=lf
+*.bash      text diff=sh        eol=lf
+*.md        text                eol=lf

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -2,6 +2,8 @@
 
 INSTALL_DIR=
 BATS_TMPDIR=${BATS_TMPDIR:-/tmp}
+fancyx='✗'
+checkmark='✓'
 
 ## We need to create a new directory so that .hasrc file in the root does not get read by the `has` instance under test
 setup() {
@@ -65,29 +67,29 @@ teardown() {
   run bash has git
 
   [[ "$status" -eq 0 ]]
-  [[ "$(echo "${output}" | grep "✔" | grep "git")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "git")" ]]
 }
 
 @test "safely tells about tools not configured" {
   run bash has foobar
 
   [[ "$status" -eq 1 ]]
-  [[ "$(echo "${output}" | grep "✘" | grep "foobar not understood")" ]]
+  [[ "$(echo "${output}" | grep ${fancyx} | grep "foobar not understood")" ]]
 }
 
 @test "env var lets override safety check" {
   HAS_ALLOW_UNSAFE=y run bash has foobar
 
   [[ "$status" -eq 1 ]]
-  [[ "$(echo "${output}" | grep "✘" | grep "foobar")" ]]
+  [[ "$(echo "${output}" | grep ${fancyx} | grep "foobar")" ]]
 }
 
 @test "status code reflects number of failed commands" {
   HAS_ALLOW_UNSAFE=y run bash has foobar bc git barbaz
 
   [[ "$status" -eq 2 ]]
-  [[ "$(echo "${output}" | grep "✘" | grep "foobar")" ]]
-  [[ "$(echo "${output}" | grep "✘" | grep "barbaz")" ]]
+  [[ "$(echo "${output}" | grep ${fancyx} | grep "foobar")" ]]
+  [[ "$(echo "${output}" | grep ${fancyx} | grep "barbaz")" ]]
 }
 
 @test "status code reflects number of failed commands upto 126" {
@@ -103,44 +105,41 @@ teardown() {
 
   [[ "$status" -eq 0 ]]
 
-  [[ "$(echo "${output}" | grep "✔" | grep "bash")" ]]
-  [[ "$(echo "${output}" | grep "✔" | grep "make")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "bash")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "make")" ]]
 }
 
 @test "loads commands from .hasrc file and honors CLI args as well" {
   printf "bash\nmake\ngit" >> .hasrc
-
   HAS_ALLOW_UNSAFE=y run bash has git bc
 
   [[ "$status" -eq 0 ]]
 
-  [[ "$(echo "${output}" | grep "✔" | grep "bash")" ]]
-  [[ "$(echo "${output}" | grep "✔" | grep "make")" ]]
-  [[ "$(echo "${output}" | grep "✔" | grep "git")" ]]
-  [[ "$(echo "${output}" | grep "✔" | grep "bc")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "bash")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "make")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "git")" ]]
+  [[ "$(echo "${output}" | grep ${checkmark} | grep "bc")" ]]
 }
 
-@test "testing PASS output with and without unicode" {
+@test "testing PASS output with unicode" {
   run bash has git
 
   [[ "$status" -eq 0 ]]
   [[ "printf '%b\n' ${lines[0]}" =~ '✓' ]]
-  [[ "printf '%s\n' ${lines[0]}" =~ '\342\234\223' ]]
 }
 
-@test "testing FAIL output with and without unicode" {
+@test "testing FAIL output with unicode" {
   run bash has foobar
 
   [[ "$status" -eq 1 ]]
-  [[ "printf '%b\n' ${lines[0]}" =~ '✘' ]]
-  [[ "printf '%s\n' ${lines[0]}" =~ '\342\234\227' ]]
+  [[ "printf '%b\n' ${lines[0]}" =~ '✗' ]]
 }
 
 @test "fail count 3: testing output with and without unicode" {
   run bash has git foobar barbaz barfoo
 
   [[ "$status" -eq 3 ]]
-  printf '%b\n' ${lines[0]} =~ '✓'
-  printf '%s\n' ${lines[1]} =~ '\342\234\227'
-  printf '%b\n' ${lines[2]} =~ '✘'
+  [[ "printf '%b\n' ${lines[0]}" =~ "${checkmark}" ]]
+  [[ "printf '%b\n' ${lines[2]}" =~ '✗' ]]
 }
+

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -29,11 +29,11 @@ teardown() {
   run "${INSTALL_DIR}/bin/has"
   [ "$status" -eq 0 ]
   [ "${lines[0]%% *}" == 'has' ]
-  [ "${lines[1]%% *}" == 'USAGE:' ]
+  [ "${lines[1]%%:*}" == 'USAGE' ]
   rm -rf ${INSTALL_DIR}
 }
 
-@test "..even if has is missing from directory" {
+@test "..even if 'has' is missing from directory" {
   INSTALL_DIR="${BATS_TEST_TMPDIR}/system_local"
   cd "${BATS_TEST_DIRNAME}"
   mv has has-been

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -48,6 +48,7 @@ teardown() {
 @test "make update runs git fetch" {
   cd "${BATS_TEST_DIRNAME}"
   run make update
+
   [[ "$status" -eq 0 ]]
   [[ "${lines[@]}" =~ "git fetch --verbose" ]]
 }
@@ -59,6 +60,7 @@ teardown() {
   [[ "$(echo "${output}" | grep "USAGE:")" ]]
   [[ "$(echo "${output}" | grep "EXAMPLE:")" ]]
 }
+
 @test "works with single command check" {
   run bash has git
 
@@ -94,7 +96,6 @@ teardown() {
   [[ "$status" -eq 126 ]]
 }
 
-
 @test "loads commands from .hasrc file and excludes comments" {
   printf "bash\n#comment\nmake\n" >> .hasrc
 
@@ -106,7 +107,7 @@ teardown() {
   [[ "$(echo "${output}" | grep "✔" | grep "make")" ]]
 }
 
-@test "loads commands from .hasrc file and honors cli args as well" {
+@test "loads commands from .hasrc file and honors CLI args as well" {
   printf "bash\nmake\ngit" >> .hasrc
 
   HAS_ALLOW_UNSAFE=y run bash has git bc
@@ -117,4 +118,29 @@ teardown() {
   [[ "$(echo "${output}" | grep "✔" | grep "make")" ]]
   [[ "$(echo "${output}" | grep "✔" | grep "git")" ]]
   [[ "$(echo "${output}" | grep "✔" | grep "bc")" ]]
+}
+
+@test "testing PASS output with and without unicode" {
+  run bash has git
+
+  [[ "$status" -eq 0 ]]
+  [[ "printf '%b\n' ${lines[0]}" =~ '✓' ]]
+  [[ "printf '%s\n' ${lines[0]}" =~ '\342\234\223' ]]
+}
+
+@test "testing FAIL output with and without unicode" {
+  run bash has foobar
+
+  [[ "$status" -eq 1 ]]
+  [[ "printf '%b\n' ${lines[0]}" =~ '✘' ]]
+  [[ "printf '%s\n' ${lines[0]}" =~ '\342\234\227' ]]
+}
+
+@test "fail count 3: testing output with and without unicode" {
+  run bash has git foobar barbaz barfoo
+
+  [[ "$status" -eq 3 ]]
+  printf '%b\n' ${lines[0]} =~ '✓'
+  printf '%s\n' ${lines[1]} =~ '\342\234\227'
+  printf '%b\n' ${lines[2]} =~ '✘'
 }

--- a/has
+++ b/has
@@ -182,7 +182,7 @@ if [[ -z "${HASRC}" ]] && [ "$#" -eq 0 ]; then
 else
   # for each cli-arg
   for cmd in "$@"; do
-      __detect "$cmd"
+      __detect "${cmd}"
   done
 
   ## display found / total
@@ -191,8 +191,8 @@ else
   ## if HASRC has been set
   if [[ -n "${HASRC}" ]]; then
     ## for all
-    for line in $(cat "${RC_FILE}" | grep -Ev "^\s*(#|$)" ); do
-      __detect "$line"
+    for line in $(grep -Ev "^\s*(#|$)" "${RC_FILE}" ); do
+      __detect "${line}"
     done
   fi
 

--- a/has
+++ b/has
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
-
 ## source: https://github.com/kdabir/has
 
 ## Important so that version is not extracted for failed commands (not found)
 set -o pipefail
 
+readonly BINARY_NAME="has"
+readonly VERSION="v1.4.0"
+
 ## constant - symbols for success failure
-PASS="\e[1m\e[38;5;2m✔\e[m"
-FAIL="\e[1m\e[38;5;1m✘\e[m"
+readonly  txtreset="$(tput sgr0)"
+readonly  txtbold="$(tput bold)"
+readonly  txtblack="$(tput setaf 0)"
+readonly  txtred="$(tput setaf 1)"
+readonly  txtgreen="$(tput setaf 2)"
+readonly  txtyellow="$(tput setaf 3)"
+readonly  txtblue="$(tput setaf 4)"
+readonly  txtpurple="$(tput setaf 5)"
+readonly  txtcyan="$(tput setaf 6)"
+readonly  txtwhite="$(tput setaf 7)"
+# unicode "✗"
+readonly  fancyx='\342\234\227'
+# unicode "✓"
+readonly  checkmark='\342\234\223'
+# PASS="\e[1m\e[38;5;2m✔\e[m"
+# FAIL="\e[1m\e[38;5;1m✘\e[m"
+readonly PASS="${txtbold}${txtgreen}${checkmark}${txtreset}"
+readonly FAIL="${txtbold}${txtred}${fancyx}${txtreset}"
 
 ## These variables are used to keep track of passed and failed commands
 OK=0
@@ -87,7 +105,6 @@ __detect(){
     lein)                   __dynamic_detect--version "${command}" ;;
     aws|eb|sls|gcloud)      __dynamic_detect--version "${command}" ;;
 
-
     # commands that need -version flag
     ant|java|javac)         __dynamic_detect-version "${command}" ;;
     scala|kotlin)           __dynamic_detect-version "${command}" ;;
@@ -121,8 +138,8 @@ __detect(){
       ;;
 
     sbt)
-        version=$(sbt about 2>&1 | grep -Eo "([[:digit:]]{1,4}\.){2}[[:digit:]]{1,4}" | head -1)
-        status=$?
+      version=$(sbt about 2>&1 | grep -Eo "([[:digit:]]{1,4}\.){2}[[:digit:]]{1,4}" | head -1)
+      status=$?
       ;;
 
     has)
@@ -143,28 +160,23 @@ __detect(){
       ;;
   esac
 
-
   if [ "$status" -eq "-1" ]; then     ## When unsafe processing is not allowed, the -1 signifies
-    printf '%s %s not understood\n' "${FAIL}" "${command}"
+    printf '%b %s not understood\n' "${FAIL}" "${command}"
     KO=$(($KO+1))
 
   elif [ ${status} -eq 127 ]; then    ## command not installed
-    printf '%s %s\n' "${FAIL}" "${command}"
+    printf '%b %s\n' "${FAIL}" "${command}"
     KO=$(($KO+1))
 
   elif [ ${status} -eq 0 ] || [ ${status} -eq 141 ]; then      ## successfully executed
-    # printf "${PASS} ${command} \e[1m\e[33;5;2m${version}\e[m\n"
-    printf "%s %s \e[1m\e[33;5;2m%s\e[m\n" "${PASS}" "${command}" "${version}"
+    printf "%b %s %b\n" "${PASS}" "${command}" "${txtbold}${txtyellow}${version}${txtreset}"
     OK=$(($OK+1))
 
   else  ## as long as its not 127, command is there, but we might not have been able to extract version
-    printf '%s %s\n' "${PASS}" "${command}"
+    printf '%b %s\n' "${PASS}" "${command}"
     OK=$(($OK+1))
   fi
-
-}
-
-
+} #end __detect
 
 if [ -s "${RC_FILE}" ];  then
   HASRC="true"
@@ -173,16 +185,14 @@ fi
 # if HASRC is not set AND no arguments passed to script
 if [[ -z "${HASRC}" ]] && [ "$#" -eq 0 ]; then
   # print help
-  BINARY_NAME="has"
-  VERSION="v1.4.0"
   printf '%s %s\n' "${BINARY_NAME}" "${VERSION}"
-  printf 'USAGE:\t\t%s <command-names>..\n' "${BINARY_NAME}"
-  printf 'EXAMPLE:\t%s git curl node\n\n' "${BINARY_NAME}"
+  printf 'USAGE:\t %s <command-names>..\n' "${BINARY_NAME}"
+  printf 'EXAMPLE: %s git curl node\n' "${BINARY_NAME}"
 
 else
   # for each cli-arg
   for cmd in "$@"; do
-      __detect "${cmd}"
+    __detect "${cmd}"
   done
 
   ## display found / total
@@ -191,9 +201,9 @@ else
   ## if HASRC has been set
   if [[ -n "${HASRC}" ]]; then
     ## for all
-    for line in $(grep -Ev "^\s*(#|$)" "${RC_FILE}" ); do
+    while read -r line; do
       __detect "${line}"
-    done
+    done <<<"$(grep -Ev "^\s*(#|$)" "${RC_FILE}" )"
   fi
 
   ## max status code that can be returned

--- a/has
+++ b/has
@@ -19,38 +19,38 @@ REGEX_SIMPLE_VERSION="([[:digit:]]+\.?){2,3}"
 ## RC file can contain commands to be tested
 RC_FILE=".hasrc"
 
-# try to extract version by executing $1 with $2 arg
+# try to extract version by executing "${1}" with "${2}" arg
 __dynamic_detect(){
-  cmd=$1
-  params=$2
-  version=$(eval ${cmd} ${params} "2>&1" | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
+  cmd="${1}"
+  params="${2}"
+  version=$(eval "${cmd}" "${params}" "2>&1" | grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
   status=$?
 }
 
 # commands that use `--version` flag
 __dynamic_detect--version(){
-  __dynamic_detect $1 "--version"
+  __dynamic_detect "${1}" "--version"
 }
 
 # commands that use `-version` flag
 __dynamic_detect-version(){
-  __dynamic_detect $1 "-version"
+  __dynamic_detect "${1}" "-version"
 }
 
 # commands that use `-v` flag
 __dynamic_detect-v(){
-  __dynamic_detect $1 "-v"
+  __dynamic_detect "${1}" "-v"
 }
 
 # commands that use `version` argument
 __dynamic_detect-arg_version(){
-  __dynamic_detect $1 "version"
+  __dynamic_detect "${1}" "version"
 }
 
 
 ## the main function
 __detect(){
-  name=$1
+  name="${1}"
 
   # setup aliases maps commonly used name to exact command name
   case ${name} in
@@ -66,57 +66,57 @@ __detect(){
     *)      command=${name} ;;
   esac
 
-  case ${command} in
+  case "${command}" in
 
     # commands that need --version flag
-    bash|zsh)               __dynamic_detect--version ${command} ;;
-    git|hg|svn|bzr)         __dynamic_detect--version ${command} ;;
-    gcc|make)               __dynamic_detect--version ${command} ;;
-    curl|wget|http)         __dynamic_detect--version ${command} ;;
-    vim|emacs|nano|subl)    __dynamic_detect--version ${command} ;;
-    bats|tree|ack|autojump) __dynamic_detect--version ${command} ;;
-    jq|ag|brew)             __dynamic_detect--version ${command} ;;
+    bash|zsh)               __dynamic_detect--version "${command}" ;;
+    git|hg|svn|bzr)         __dynamic_detect--version "${command}" ;;
+    gcc|make)               __dynamic_detect--version "${command}" ;;
+    curl|wget|http)         __dynamic_detect--version "${command}" ;;
+    vim|emacs|nano|subl)    __dynamic_detect--version "${command}" ;;
+    bats|tree|ack|autojump) __dynamic_detect--version "${command}" ;;
+    jq|ag|brew)             __dynamic_detect--version "${command}" ;;
 
-    R)                      __dynamic_detect--version ${command} ;;
-    node|npm|yarn)          __dynamic_detect--version ${command} ;;
-    grunt|brunch)           __dynamic_detect--version ${command} ;;
-    ruby|gem|rake|bundle)   __dynamic_detect--version ${command} ;;
-    python|python3)         __dynamic_detect--version ${command} ;;
-    perl|perl6|php|php5)    __dynamic_detect--version ${command} ;;
-    groovy|gradle|mvn)      __dynamic_detect--version ${command} ;;
-    lein)                   __dynamic_detect--version ${command} ;;
-    aws|eb|sls|gcloud)      __dynamic_detect--version ${command} ;;
+    R)                      __dynamic_detect--version "${command}" ;;
+    node|npm|yarn)          __dynamic_detect--version "${command}" ;;
+    grunt|brunch)           __dynamic_detect--version "${command}" ;;
+    ruby|gem|rake|bundle)   __dynamic_detect--version "${command}" ;;
+    python|python3)         __dynamic_detect--version "${command}" ;;
+    perl|perl6|php|php5)    __dynamic_detect--version "${command}" ;;
+    groovy|gradle|mvn)      __dynamic_detect--version "${command}" ;;
+    lein)                   __dynamic_detect--version "${command}" ;;
+    aws|eb|sls|gcloud)      __dynamic_detect--version "${command}" ;;
 
 
     # commands that need -version flag
-    ant|java|javac)         __dynamic_detect-version ${command} ;;
-    scala|kotlin)           __dynamic_detect-version ${command} ;;
+    ant|java|javac)         __dynamic_detect-version "${command}" ;;
+    scala|kotlin)           __dynamic_detect-version "${command}" ;;
 
     # commands that need version arg
-    hugo)                   __dynamic_detect-arg_version ${command} ;;
+    hugo)                   __dynamic_detect-arg_version "${command}" ;;
 
     ## Example of commands that need custom processing
     ## go needs version arg
     go)
-      version=$(go version 2>&1| grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(go version 2>&1| grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
       status=$?
       ;;
 
     ## TODO cleanup, currently need to add extra space in regex, otherwise the time gets selected
     gulp)
-      version=$(gulp --version 2>&1| grep -Eo " $REGEX_SIMPLE_VERSION" | head -1)
+      version=$(gulp --version 2>&1| grep -Eo " ${REGEX_SIMPLE_VERSION}" | head -1)
       status=$?
       ;;
 
     ## ab uses -V flag
     ab)
-      version=$(ab -V 2>&1 | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(ab -V 2>&1 | grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
       status=$?
       ;;
 
     ## gor returns version but does not return normal status code, hence needs custom processing
     gor)
-      version=$(gor version 2>&1 | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(gor version 2>&1 | grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
       if [ $? -eq 1 ]; then status=0; else status=1; fi
       ;;
 
@@ -126,14 +126,14 @@ __detect(){
       ;;
 
     has)
-      version=$(has 2>&1 | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(has 2>&1 | grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
       status=$?
       ;;
 
     *)
       ## Can allow dynamic checking here, i.e. checking commands that are not listed above
       if [[ "${HAS_ALLOW_UNSAFE}" == "y" ]]; then
-        __dynamic_detect--version ${command}
+        __dynamic_detect--version "${command}"
         ## fallback checking based on status!=127 (127 means command not found)
         ## TODO can check other type of supported version-checks if status was not 127
       else

--- a/has
+++ b/has
@@ -23,7 +23,7 @@ RC_FILE=".hasrc"
 __dynamic_detect(){
   cmd=$1
   params=$2
-  version=$(eval ${cmd} ${params} "2>&1" | egrep -o "$REGEX_SIMPLE_VERSION" | head -1)
+  version=$(eval ${cmd} ${params} "2>&1" | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
   status=$?
 }
 
@@ -98,35 +98,35 @@ __detect(){
     ## Example of commands that need custom processing
     ## go needs version arg
     go)
-      version=$(go version 2>&1| egrep -o "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(go version 2>&1| grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
       status=$?
       ;;
 
     ## TODO cleanup, currently need to add extra space in regex, otherwise the time gets selected
     gulp)
-      version=$(gulp --version 2>&1| egrep -o " $REGEX_SIMPLE_VERSION" | head -1)
+      version=$(gulp --version 2>&1| grep -Eo " $REGEX_SIMPLE_VERSION" | head -1)
       status=$?
       ;;
 
     ## ab uses -V flag
     ab)
-      version=$(ab -V 2>&1 | egrep -o "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(ab -V 2>&1 | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
       status=$?
       ;;
 
     ## gor returns version but does not return normal status code, hence needs custom processing
     gor)
-      version=$(gor version 2>&1 | egrep -o "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(gor version 2>&1 | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
       if [ $? -eq 1 ]; then status=0; else status=1; fi
       ;;
 
     sbt)
-        version=$(sbt about 2>&1 | egrep -o "([[:digit:]]{1,4}\.){2}[[:digit:]]{1,4}" | head -1)
+        version=$(sbt about 2>&1 | grep -Eo "([[:digit:]]{1,4}\.){2}[[:digit:]]{1,4}" | head -1)
         status=$?
       ;;
 
     has)
-      version=$(has 2>&1 | egrep -o "$REGEX_SIMPLE_VERSION" | head -1)
+      version=$(has 2>&1 | grep -Eo "$REGEX_SIMPLE_VERSION" | head -1)
       status=$?
       ;;
 
@@ -190,7 +190,7 @@ else
   ## if HASRC has been set
   if [[ -n "${HASRC}" ]]; then
     ## for all
-    for line in $(cat "${RC_FILE}" | egrep -v "^\s*(#|$)" ); do
+    for line in $(cat "${RC_FILE}" | grep -Ev "^\s*(#|$)" ); do
       __detect "$line"
     done
   fi

--- a/has
+++ b/has
@@ -145,19 +145,20 @@ __detect(){
 
 
   if [ "$status" -eq "-1" ]; then     ## When unsafe processing is not allowed, the -1 signifies
-    printf "${FAIL} ${command} not understood\n"
+    printf '%s %s not understood\n' "${FAIL}" "${command}"
     KO=$(($KO+1))
 
   elif [ ${status} -eq 127 ]; then    ## command not installed
-    printf "${FAIL} ${command}\n"
+    printf '%s %s\n' "${FAIL}" "${command}"
     KO=$(($KO+1))
 
   elif [ ${status} -eq 0 ] || [ ${status} -eq 141 ]; then      ## successfully executed
-    printf "${PASS} ${command} \e[1m\e[33;5;2m${version}\e[m\n"
+    # printf "${PASS} ${command} \e[1m\e[33;5;2m${version}\e[m\n"
+    printf "%s %s \e[1m\e[33;5;2m%s\e[m\n" "${PASS}" "${command}" "${version}"
     OK=$(($OK+1))
 
   else  ## as long as its not 127, command is there, but we might not have been able to extract version
-    printf "${PASS} ${command}\n"
+    printf '%s %s\n' "${PASS}" "${command}"
     OK=$(($OK+1))
   fi
 
@@ -174,9 +175,9 @@ if [[ -z "${HASRC}" ]] && [ "$#" -eq 0 ]; then
   # print help
   BINARY_NAME="has"
   VERSION="v1.4.0"
-  printf "${BINARY_NAME} ${VERSION}\n"
-  printf "USAGE:    ${BINARY_NAME} <command-names>..\n"
-  printf "EXAMPLE:  ${BINARY_NAME} git curl node\n\n"
+  printf '%s %s\n' "${BINARY_NAME}" "${VERSION}"
+  printf 'USAGE:\t\t%s <command-names>..\n' "${BINARY_NAME}"
+  printf 'EXAMPLE:\t%s git curl node\n\n' "${BINARY_NAME}"
 
 else
   # for each cli-arg


### PR DESCRIPTION
# What's in this PR?
* Linting with shellcheck
* Update Unicode PASS/FAIL output
* Repo scaffolding - shellscript filetype

## Linting with shellcheck

- [x] [SC2196] Use grep -E. egrep is non-standard and deprecated.
- [x] [SC2086] Double quoting and curly braces
- [x] [SC2059] printf syntax
- [x] [SC2002] Useless cat

## Update Unicode PASS/FAIL output

- [x] NEW variables for 'checkmark' and 'fancy x' and tput colours
  - [x] eg: `checkmark` = `\342\234\223` (or `$'\u2713'`)
  - [x] eg: `PASS=${txtbold}${txtgreen}${checkmark}${txtreset}` 
  - [x] update `printf` statements to use `%b` for unicode variables.
- [x] Using readonly variables for
  - [x] $BINARY_NAME and $VERSION
  - [x] $PASS and $FAIL
- [x] refactor `.hasrc` file reading
  - [x] [SC2002] Useless cat
- [x] Add new BATS tests for Unicode output
  - [x] Add same unicode variables from `has` binary to `.hastest.bats`
## Repo scaffolding - shellscript filetype

- [x] Add shellscripts to `.editorconfig`
- [x] Add shellscripts to `.gitattributes`