### PR TITLE
Fix bug when `gor` not installed

### DIFF
--- a/has
+++ b/has
@@ -176,7 +176,7 @@ __detect(){
     ## gor returns version but does not return normal status code, hence needs custom processing
     gor)
       version=$( gor version 2>&1 | grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
-      if [ $? -eq 1 ]; then status=0; else status=1; fi
+      if [ $? -eq 1 ]; then status=0; else status=127; fi
       ;;
 
     sbt)


### PR DESCRIPTION
![aaa](https://user-images.githubusercontent.com/4313010/66364227-3785aa00-e946-11e9-8e57-f1514c2411ce.png)

The above show's a before and after applying the fix. Before when `goreplay` wasn't installed it would still show the green checkmark even though it was missing, after the fix it properly shows the red `x`.