### PR TITLE
fixing tests on ubuntu

### DIFF
--- a/tests/containers/alpine.Dockerfile
+++ b/tests/containers/alpine.Dockerfile
@@ -56,12 +56,12 @@ RUN apk add --no-cache \
     # required for brew and lein
     ln -s $(which bash) /bin/bash && \
     \
-    npm install --global \
+    npm install --global --no-optional \
         brunch@"=3.0.0" \
         grunt-cli@"=1.3.2" \
         gulp-cli@"=2.2.0" \
         heroku@"=7.39.3" \
-        netlify-cli@"=2.46.0" \
+        netlify-cli@"=2.33.0" \
         serverless@"=1.67.3" `# sls=1.67.3` && \
     \
     autojump=22.5.3 && \

--- a/tests/containers/ubuntu.Dockerfile
+++ b/tests/containers/ubuntu.Dockerfile
@@ -136,12 +136,12 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install --no-inst
     \
     curl -L "https://nodejs.org/dist/v${node}/node-v${node}-linux-x64.tar.gz" | tar xz && \
     \
-    npm install --global `# npm=6.14.5` \
+    npm install --global --no-optional `# npm=6.14.5` \
         brunch@"=3.0.0" \
         grunt-cli@"=1.3.2" \
         gulp-cli@"=2.2.0" \
         heroku@"=7.39.3" \
-        netlify-cli@"=2.46.0" \
+        netlify-cli@"=2.33.0" \
         serverless@"=1.67.3" `# sls=1.67.3` && \
     \
     apt-get -y autoremove && apt-get -y clean && rm -rf /var/lib/apt/lists/*

--- a/tests/containers/ubuntu.Dockerfile
+++ b/tests/containers/ubuntu.Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:bionic-20200311
 
+# Updates path with node, npm, npx, and globally installed npm packages
+ENV node=12.18.1
+ENV PATH="${PATH}:/node-v${node}-linux-x64/bin"
+
 # already contains
 #       apt=1.6.12
 #       apt-get=1.6.12
@@ -85,7 +89,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install --no-inst
     dpkg -i code_${code}.deb || apt-get install -f -y && \
     rm -f code_${code}.deb && \
     \
-    commit="102025c" `# eb=3.18.0` && \
+    commit="102025c" `# eb=3.18.1` && \
     curl -L "https://github.com/aws/aws-elastic-beanstalk-cli-setup/tarball/${commit}" | tar xz && \
     "aws-aws-elastic-beanstalk-cli-setup-${commit}/scripts/bundled_installer" && \
     ln -s /root/.ebcli-virtual-env/executables/eb /usr/local/bin/eb && \
@@ -130,13 +134,9 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install --no-inst
         sublime-text=3211 `# subl=3211` && \
     ln -s /usr/bin/php5.6 /usr/bin/php5 && \
     \
-    node=12.18.1 `# npm=6.14.5` && \
     curl -L "https://nodejs.org/dist/v${node}/node-v${node}-linux-x64.tar.gz" | tar xz && \
-    ln -s "/node-v${node}-linux-x64/bin/node" /usr/local/bin/node && \
-    ln -s "/node-v${node}-linux-x64/bin/npm"  /usr/local/bin/npm  && \
-    ln -s "/node-v${node}-linux-x64/bin/npx"  /usr/local/bin/npx `# todo` && \
     \
-    npm install --global \
+    npm install --global `# npm=6.14.5` \
         brunch@"=3.0.0" \
         grunt-cli@"=1.3.2" \
         gulp-cli@"=2.2.0" \


### PR DESCRIPTION
fix expected eb vesion

add node packages to path

update: recent versions of netlify-cli aren't installing as part of the containers due to dependency issues. My most recent commit drops netlify-cli back to 2.33.0 which they released in February 2020. Both Alpine and Ubuntu containers should build properly now :+1: . GitHub Actions tests should all pass after these containers are rebuilt.