### PR TITLE
Turn off GitHub Actions fail-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         container:
           - debian # uses debian:buster-20200327-slim which is debian 10.3
@@ -36,6 +37,7 @@ jobs:
     name: test_all
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         container:
           - ubuntu # uses ubuntu:bionic-20200311 which is ubuntu 18.04


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

Prevent GitHub from canceling all in-progress and queued jobs in the matrix if any job in the matrix fails.