### PR TITLE
Fixes shellcheck warnings

### DIFF
--- a/has
+++ b/has
@@ -16,19 +16,19 @@ elif [[ -z $TERM ]]; then
   TERM="xterm"
 fi
 
-txtreset="$(tput -T $TERM sgr0)"
+txtreset="$(tput -T "$TERM" sgr0)"
 readonly txtreset
 
-txtbold="$(tput -T $TERM bold)"
+txtbold="$(tput -T "$TERM" bold)"
 readonly txtbold
 
-txtred="$(tput -T $TERM setaf 1)"
+txtred="$(tput -T "$TERM" setaf 1)"
 readonly txtred
 
-txtgreen="$(tput -T $TERM setaf 2)"
+txtgreen="$(tput -T "$TERM" setaf 2)"
 readonly txtgreen
 
-txtyellow="$(tput -T $TERM setaf 3)"
+txtyellow="$(tput -T "$TERM" setaf 3)"
 readonly txtyellow
 
 # unicode "✗"
@@ -44,7 +44,7 @@ readonly FAIL="${txtbold}${txtred}${fancyx}${txtreset}"
 COLOR_AUTO="auto"
 COLOR_NEVER="never"
 COLOR_ALWAYS="always"
-COLOR_OPTS=(${COLOR_AUTO} ${COLOR_NEVER} ${COLOR_ALWAYS})
+COLOR_OPTS=( "${COLOR_AUTO}" "${COLOR_NEVER}" "${COLOR_ALWAYS}")
 COLOR="${COLOR_AUTO}"
 COLOR_PREFIX="--color"
 
@@ -355,8 +355,8 @@ while getopts ":qhv-" OPTION; do
   -)
     [ $OPTIND -ge 1 ] && optind=$(expr $OPTIND - 1) || optind=$OPTIND
     eval OPTION="\$$optind"
-    OPTARG=$(echo $OPTION | cut -d'=' -f2)
-    OPTION=$(echo $OPTION | cut -d'=' -f1)
+    OPTARG=$(echo "$OPTION" | cut -d'=' -f2)
+    OPTION=$(echo "$OPTION" | cut -d'=' -f1)
     case $OPTION in
     --version)
       _version

--- a/has
+++ b/has
@@ -352,7 +352,7 @@ while getopts ":qhv-" OPTION; do
     exit 0
     ;;
   -)
-    [ $OPTIND -ge 1 ] && optind=$(expr $OPTIND - 1) || optind=$OPTIND
+    [ $OPTIND -ge 1 ] && optind=$((OPTIND - 1)) || optind=$OPTIND
     eval OPTION="\$$optind"
     OPTARG=$(echo "$OPTION" | cut -d'=' -f2)
     OPTION=$(echo "$OPTION" | cut -d'=' -f1)

--- a/has
+++ b/has
@@ -22,9 +22,6 @@ readonly txtreset
 txtbold="$(tput -T $TERM bold)"
 readonly txtbold
 
-txtblack="$(tput -T $TERM setaf 0)"
-readonly txtblack
-
 txtred="$(tput -T $TERM setaf 1)"
 readonly txtred
 
@@ -33,18 +30,6 @@ readonly txtgreen
 
 txtyellow="$(tput -T $TERM setaf 3)"
 readonly txtyellow
-
-txtblue="$(tput -T $TERM setaf 4)"
-readonly txtblue
-
-txtpurple="$(tput -T $TERM setaf 5)"
-readonly txtpurple
-
-txtcyan="$(tput -T $TERM setaf 6)"
-readonly txtcyan
-
-txtwhite="$(tput -T $TERM setaf 7)"
-readonly txtwhite
 
 # unicode "✗"
 readonly fancyx='\342\234\227'

--- a/has
+++ b/has
@@ -15,16 +15,37 @@ if [[ ! -t 1 ]]; then
 elif [[ -z $TERM ]]; then
   TERM="xterm"
 fi
-readonly txtreset="$(tput -T $TERM sgr0)"
-readonly txtbold="$(tput -T $TERM bold)"
-readonly txtblack="$(tput -T $TERM setaf 0)"
-readonly txtred="$(tput -T $TERM setaf 1)"
-readonly txtgreen="$(tput -T $TERM setaf 2)"
-readonly txtyellow="$(tput -T $TERM setaf 3)"
-readonly txtblue="$(tput -T $TERM setaf 4)"
-readonly txtpurple="$(tput -T $TERM setaf 5)"
-readonly txtcyan="$(tput -T $TERM setaf 6)"
-readonly txtwhite="$(tput -T $TERM setaf 7)"
+
+txtreset="$(tput -T $TERM sgr0)"
+readonly txtreset
+
+txtbold="$(tput -T $TERM bold)"
+readonly txtbold
+
+txtblack="$(tput -T $TERM setaf 0)"
+readonly txtblack
+
+txtred="$(tput -T $TERM setaf 1)"
+readonly txtred
+
+txtgreen="$(tput -T $TERM setaf 2)"
+readonly txtgreen
+
+txtyellow="$(tput -T $TERM setaf 3)"
+readonly txtyellow
+
+txtblue="$(tput -T $TERM setaf 4)"
+readonly txtblue
+
+txtpurple="$(tput -T $TERM setaf 5)"
+readonly txtpurple
+
+txtcyan="$(tput -T $TERM setaf 6)"
+readonly txtcyan
+
+txtwhite="$(tput -T $TERM setaf 7)"
+readonly txtwhite
+
 # unicode "✗"
 readonly fancyx='\342\234\227'
 # unicode "✓"

--- a/has
+++ b/has
@@ -44,7 +44,7 @@ readonly FAIL="${txtbold}${txtred}${fancyx}${txtreset}"
 COLOR_AUTO="auto"
 COLOR_NEVER="never"
 COLOR_ALWAYS="always"
-COLOR_OPTS=( "${COLOR_AUTO}" "${COLOR_NEVER}" "${COLOR_ALWAYS}")
+COLOR_OPTS=("${COLOR_AUTO} ${COLOR_NEVER} ${COLOR_ALWAYS}")
 COLOR="${COLOR_AUTO}"
 COLOR_PREFIX="--color"
 

--- a/has
+++ b/has
@@ -341,7 +341,6 @@ OUTPUT=/dev/stdout
 while getopts ":qhv-" OPTION; do
   case "$OPTION" in
   q)
-    QUIET="true"
     OUTPUT=/dev/null
     ;;
   h)


### PR DESCRIPTION
Related to #74

- Removed unused variables (SC2034)
- Declare and assign variables separately (SC2155)
- Double quotes for variables (SC2086) (SC2206)
- Replace expr (SC2003)