### PR TITLE
Refine git clone commands in Dockerfiles

### DIFF
--- a/tests/containers/alpine.Dockerfile
+++ b/tests/containers/alpine.Dockerfile
@@ -76,7 +76,7 @@ RUN apk add --no-cache \
     "bats-core-bats-core-${commit}/install.sh" /usr/local && \
     \
     brew=2.2.13 && \
-    git clone --branch ${brew} https://github.com/Homebrew/brew && \
+    git clone --depth=1 --branch ${brew} https://github.com/Homebrew/brew && \
     eval $(brew/bin/brew shellenv) && \
     ln -s /brew/bin/brew /usr/local/bin/brew && \
     brew --version && \

--- a/tests/containers/ubuntu.Dockerfile
+++ b/tests/containers/ubuntu.Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install --no-inst
     "bats-core-bats-core-${commit}/install.sh" /usr/local && \
     \
     brew=2.2.13 && \
-    git clone --branch ${brew} https://github.com/Homebrew/brew && \
+    git clone --depth=1 --branch ${brew} https://github.com/Homebrew/brew && \
     locale-gen en_US en_US.UTF-8 && \
     eval $(brew/bin/brew shellenv) && \
     ln -s /brew/bin/brew /usr/local/bin/brew && \


### PR DESCRIPTION
Adjusted git clone commands in Dockerfiles to use `--depth=1`. This optimizes the cloning process by fetching a limited history, thereby saving resources and time.