### PR TITLE
cleanup packages_all.sh output

### DIFF
--- a/tests/packages_all.sh
+++ b/tests/packages_all.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
-grep -o "^ \\+[a-zA-Z0-9_|-]\\+)" ../has | grep -o "[a-zA-Z0-9_|-]\\+" | tr "|" "\\n" | sort -f
+grep -o "^ \\+[a-zA-Z0-9][a-zA-Z0-9_|-]\\+)" ../has | grep -o "[a-zA-Z0-9_|-]\\+" | tr "|" "\\n" | sort -f
 
 popd >/dev/null


### PR DESCRIPTION
This fix removes the `--help`, `--version`, `q`, `v`, `h` from `packages_all.sh` output