### PR TITLE
Fix CLI options parser in 'has' + updated 'packages_all.sh' 

### DIFF
--- a/.hasrc
+++ b/.hasrc
@@ -1,0 +1,6 @@
+# make to install/test the project
+make
+curl
+git
+# bats for testing
+bats

--- a/.hasrc
+++ b/.hasrc
@@ -1,6 +1,0 @@
-# make to install/test the project
-make
-curl
-git
-# bats for testing
-bats

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -26,10 +26,11 @@ teardown() {
   [ "${lines[0]}" = 'Usage: has [OPTION] <command-names>...' ]
   [ "${lines[1]}" = 'Has checks the presence of various command line tools on the PATH and reports their installed version.' ]
   [ "${lines[2]}" = 'Options:' ]
-  [ "${lines[3]}" = '        -q              Silent mode' ]
-  [ "${lines[4]}" = '        -h, --help      Display this help text and quit' ]
-  [ "${lines[5]}" = '        -V, --version   Show version number and quit' ]
-  [ "${lines[6]}" = 'Examples: has git curl node' ]
+  [ "${lines[3]}" = '        -q                           Silent mode' ]
+  [ "${lines[4]}" = '        -h, --help                   Display this help text and quit' ]
+  [ "${lines[5]}" = '        -V, --version                Show version number and quit' ]
+  [ "${lines[6]}" = '        --color [auto|never|always]  Use colors (default: auto)' ]
+  [ "${lines[7]}" = 'Examples: has git curl node' ]
 }
 
 @test "make install creates a valid installation" {
@@ -47,10 +48,11 @@ teardown() {
   [ "${lines[0]}" = 'Usage: has [OPTION] <command-names>...' ]
   [ "${lines[1]}" = 'Has checks the presence of various command line tools on the PATH and reports their installed version.' ]
   [ "${lines[2]}" = 'Options:' ]
-  [ "${lines[3]}" = '        -q              Silent mode' ]
-  [ "${lines[4]}" = '        -h, --help      Display this help text and quit' ]
-  [ "${lines[5]}" = '        -V, --version   Show version number and quit' ]
-  [ "${lines[6]}" = 'Examples: has git curl node' ]
+  [ "${lines[3]}" = '        -q                           Silent mode' ]
+  [ "${lines[4]}" = '        -h, --help                   Display this help text and quit' ]
+  [ "${lines[5]}" = '        -V, --version                Show version number and quit' ]
+  [ "${lines[6]}" = '        --color [auto|never|always]  Use colors (default: auto)' ]
+  [ "${lines[7]}" = 'Examples: has git curl node' ]
 }
 
 @test "..even if 'has' is missing from directory" {
@@ -210,10 +212,11 @@ teardown() {
   [ "${lines[0]}" = 'Usage: has [OPTION] <command-names>...' ]
   [ "${lines[1]}" = 'Has checks the presence of various command line tools on the PATH and reports their installed version.' ]
   [ "${lines[2]}" = 'Options:' ]
-  [ "${lines[3]}" = '        -q              Silent mode' ]
-  [ "${lines[4]}" = '        -h, --help      Display this help text and quit' ]
-  [ "${lines[5]}" = '        -V, --version   Show version number and quit' ]
-  [ "${lines[6]}" = 'Examples: has git curl node' ]
+  [ "${lines[3]}" = '        -q                           Silent mode' ]
+  [ "${lines[4]}" = '        -h, --help                   Display this help text and quit' ]
+  [ "${lines[5]}" = '        -V, --version                Show version number and quit' ]
+  [ "${lines[6]}" = '        --color [auto|never|always]  Use colors (default: auto)' ]
+  [ "${lines[7]}" = 'Examples: has git curl node' ]
 }
 
 @test "status code in quiet mode still equal to number of failed commands" {

--- a/.hastest.bats
+++ b/.hastest.bats
@@ -28,7 +28,7 @@ teardown() {
   [ "${lines[2]}" = 'Options:' ]
   [ "${lines[3]}" = '        -q                           Silent mode' ]
   [ "${lines[4]}" = '        -h, --help                   Display this help text and quit' ]
-  [ "${lines[5]}" = '        -V, --version                Show version number and quit' ]
+  [ "${lines[5]}" = '        -v, --version                Show version number and quit' ]
   [ "${lines[6]}" = '        --color [auto|never|always]  Use colors (default: auto)' ]
   [ "${lines[7]}" = 'Examples: has git curl node' ]
 }
@@ -50,7 +50,7 @@ teardown() {
   [ "${lines[2]}" = 'Options:' ]
   [ "${lines[3]}" = '        -q                           Silent mode' ]
   [ "${lines[4]}" = '        -h, --help                   Display this help text and quit' ]
-  [ "${lines[5]}" = '        -V, --version                Show version number and quit' ]
+  [ "${lines[5]}" = '        -v, --version                Show version number and quit' ]
   [ "${lines[6]}" = '        --color [auto|never|always]  Use colors (default: auto)' ]
   [ "${lines[7]}" = 'Examples: has git curl node' ]
 }
@@ -214,7 +214,7 @@ teardown() {
   [ "${lines[2]}" = 'Options:' ]
   [ "${lines[3]}" = '        -q                           Silent mode' ]
   [ "${lines[4]}" = '        -h, --help                   Display this help text and quit' ]
-  [ "${lines[5]}" = '        -V, --version                Show version number and quit' ]
+  [ "${lines[5]}" = '        -v, --version                Show version number and quit' ]
   [ "${lines[6]}" = '        --color [auto|never|always]  Use colors (default: auto)' ]
   [ "${lines[7]}" = 'Examples: has git curl node' ]
 }

--- a/has
+++ b/has
@@ -341,13 +341,14 @@ __detect(){
 OUTPUT=/dev/stdout
 
 OPTS=$(getopt -o qvh --long quiet,version,help,color: -- "$@")
+# shellcheck disable=SC2181
 if [[ $? -ne 0 ]]; then
     _usage
     exit 1;
 fi
 
 eval set -- "$OPTS"
-while [ : ]; do
+while true; do
   case "$1" in
     -q | --quiet)
         OUTPUT=/dev/null

--- a/has
+++ b/has
@@ -44,9 +44,8 @@ readonly FAIL="${txtbold}${txtred}${fancyx}${txtreset}"
 COLOR_AUTO="auto"
 COLOR_NEVER="never"
 COLOR_ALWAYS="always"
-COLOR_OPTS=("${COLOR_AUTO} ${COLOR_NEVER} ${COLOR_ALWAYS}")
+COLOR_OPTS=("${COLOR_AUTO}" "${COLOR_NEVER}" "${COLOR_ALWAYS}")
 COLOR="${COLOR_AUTO}"
-COLOR_PREFIX="--color"
 
 ## These variables are used to keep track of passed and failed commands
 OK=0
@@ -64,9 +63,10 @@ Usage: ${BINARY_NAME} [OPTION] <command-names>...
 Has checks the presence of various command line tools on the PATH and reports their installed version.
 
 Options:
-        -q              Silent mode
-        -h, --help      Display this help text and quit
-        -V, --version   Show version number and quit
+        -q                           Silent mode
+        -h, --help                   Display this help text and quit
+        -V, --version                Show version number and quit
+        --color [auto|never|always]  Use colors (default: auto)
 
 Examples: ${BINARY_NAME} git curl node
 EOF
@@ -80,7 +80,7 @@ _version() {
 _set_color() {
   local found=0;
   for opt in "${COLOR_OPTS[@]}"; do
-    [ "${1}" == "${COLOR_PREFIX}-${opt}" ] && COLOR="${opt}" && found=1 && break
+    [ "${1}" == "${opt}" ] && COLOR="${opt}" && found=1 && break
   done
   [ ${found} -eq 1 ] || >&2 echo "Error: wrong flag ${1}"
 }
@@ -338,57 +338,38 @@ __detect(){
   fi
 } #end __detect
 
-OPTIND=1
 OUTPUT=/dev/stdout
 
-while getopts ":qhv-" OPTION; do
-  case "$OPTION" in
-  q)
-    OUTPUT=/dev/null
-    ;;
-  h)
+OPTS=$(getopt -o qvh --long quiet,version,help,color: -- "$@")
+if [[ $? -ne 0 ]]; then
     _usage
-    exit 0
-    ;;
-  v)
-    _version
-    exit 0
-    ;;
-  -)
-    [ $OPTIND -ge 1 ] && optind=$((OPTIND - 1)) || optind=$OPTIND
-    eval OPTION="\$$optind"
-    OPTARG=$(echo "$OPTION" | cut -d'=' -f2)
-    OPTION=$(echo "$OPTION" | cut -d'=' -f1)
-    case $OPTION in
-    --version)
-      _version
-      exit 0
-      ;;
-    --help)
-      _usage
-      exit 0
-      ;;
-    ${COLOR_PREFIX}*)
-      _set_color "${OPTION}"
-      ;;
-    *)
-      printf '%s: unrecognized option '%s'\n' "${BINARY_NAME}" "${OPTARG}"
-      _usage
-      exit 2
-      ;;
-    esac
-    OPTIND=1
-    shift
-    ;;
-  ?)
-    printf '%s: unrecognized option '%s'\n' "${BINARY_NAME}" "${OPTARG}"
-    _usage
-    exit 2
-    ;;
-  esac
-done
+    exit 1;
+fi
 
-shift $((OPTIND - 1))
+eval set -- "$OPTS"
+while [ : ]; do
+  case "$1" in
+    -q | --quiet)
+        OUTPUT=/dev/null
+        ;;
+    -v | --version)
+        _version
+        exit 0
+        ;;
+    -h | --help)
+        _usage
+        exit 0
+        ;;
+    --color)
+        shift
+        _set_color "$1"
+        ;;
+    --) shift
+        break
+        ;;
+  esac
+  shift
+done
 
 if [ -s "${RC_FILE}" ];  then
   HASRC="true"

--- a/has
+++ b/has
@@ -66,7 +66,7 @@ Has checks the presence of various command line tools on the PATH and reports th
 Options:
         -q              Silent mode
         -h, --help      Display this help text and quit
-        -V, --version   Show version number and quit
+        -v, --version   Show version number and quit
 
 Examples: ${BINARY_NAME} git curl node
 EOF

--- a/has
+++ b/has
@@ -65,7 +65,7 @@ Has checks the presence of various command line tools on the PATH and reports th
 Options:
         -q                           Silent mode
         -h, --help                   Display this help text and quit
-        -V, --version                Show version number and quit
+        -v, --version                Show version number and quit
         --color [auto|never|always]  Use colors (default: auto)
 
 Examples: ${BINARY_NAME} git curl node

--- a/tests/packages_all.sh
+++ b/tests/packages_all.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
-grep -o "^ \\+[a-zA-Z0-9_|-]\\+)" ../has | grep -o "[a-zA-Z0-9_|-]\\+" | tr "|" "\\n" | sort -f
+grep -o "^ \\+[a-zA-Z0-9][a-zA-Z0-9_|-]\\+)" ../has | grep -o "[a-zA-Z0-9_|-]\\+" | tr "|" "\\n" | sort -f
 
 popd >/dev/null


### PR DESCRIPTION
Sorry for the noise (several PR I closed), I muddled a bit between my branches.

Therefore this PR:
1. `getopt` instead of bash built-in `getopts` -> it fixes the long options parser
2. fixed `--color` option
3. updated `_usage()`: added `--color` explanation, + small typo (`-v` instead of `-V`)
4. updated tests due to 2.
5. updated `packages_all.sh` regex in order to remove `version`, `help`, etc. from its output