### PR TITLE
feat: add shell completions for bash and zsh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,25 @@ has :
 	# ensure 'has' in repo
 	git checkout --force -- has
 
+# Completion directories
+BASH_COMPLETION_DIR := $(DESTDIR)$(PREFIX)/share/bash-completion/completions
+ZSH_COMPLETION_DIR := $(DESTDIR)$(PREFIX)/share/zsh/site-functions
+
 # install 'has' in specified directory
 install : has
 	chmod 755 has && \
 	mkdir -v -p $(DESTDIR)$(PREFIX)/bin && \
 	cp -v has $(DESTDIR)$(PREFIX)/bin/has
+
+# install shell completions
+install-completions:
+	mkdir -v -p $(BASH_COMPLETION_DIR) && \
+	mkdir -v -p $(ZSH_COMPLETION_DIR) && \
+	cp -v completions/has.bash $(BASH_COMPLETION_DIR)/has && \
+	cp -v completions/_has $(ZSH_COMPLETION_DIR)/_has
+
+# install everything
+install-all: install install-completions
 
 # update: has
 update : update-fetch has
@@ -43,7 +57,13 @@ update-force :
 uninstall :
 	rm -f $(DESTDIR)$(PREFIX)/bin/has
 
-.PHONY: test install uninstall update
+uninstall-completions:
+	rm -f $(BASH_COMPLETION_DIR)/has
+	rm -f $(ZSH_COMPLETION_DIR)/_has
+
+uninstall-all: uninstall uninstall-completions
+
+.PHONY: test install install-completions install-all uninstall uninstall-completions uninstall-all update
 
 CONTAINERS = ubuntu alpine
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,28 @@ make PREFIX=$HOME/.local install
 
 To update just do a `git fetch` or `make update` followed by the appropriate `make install` command.
 
+#### Installing Shell Completions
+
+After cloning the repo, you can install shell completions for bash and zsh:
+
+```bash
+# Install everything (has + completions)
+sudo make install-all
+
+# Or install completions separately
+sudo make install-completions
+```
+
+For non-root installation:
+
+```bash
+make PREFIX=$HOME/.local install-all
+```
+
+The completions will be installed to:
+- Bash: `$PREFIX/share/bash-completion/completions/has`
+- Zsh: `$PREFIX/share/zsh/site-functions/_has`
+
 ### Downloading to a file
 
 ```bash

--- a/completions/_has
+++ b/completions/_has
@@ -1,0 +1,22 @@
+#compdef has
+
+# Zsh completion script for 'has' - https://github.com/kdabir/has
+# A simple utility to check the presence of command line tools
+
+_has() {
+  local -a opts
+  opts=(
+    '-q[Silent mode]'
+    '(-h --help)'{-h,--help}'[Display this help text and quit]'
+    '(-v --version)'{-v,--version}'[Show version number and quit]'
+    '--color-auto[Enable color output automatically (default)]'
+    '--color-never[Disable color output]'
+    '--color-always[Always enable color output]'
+  )
+
+  _arguments -s -S \
+    $opts \
+    '*: :_command_names -e'
+}
+
+_has "$@"

--- a/completions/has.bash
+++ b/completions/has.bash
@@ -1,0 +1,24 @@
+# Bash completion script for 'has' - https://github.com/kdabir/has
+# A simple utility to check the presence of command line tools
+
+_has_completions() {
+  local cur prev opts commands
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  
+  # Options for has
+  opts="-q -h --help -v --version --color-auto --color-never --color-always"
+  
+  # If current word starts with a dash, complete options
+  if [[ ${cur} == -* ]]; then
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    return 0
+  fi
+  
+  # Otherwise, complete with available commands on the system
+  COMPREPLY=( $(compgen -c -- ${cur}) )
+  return 0
+}
+
+complete -F _has_completions has


### PR DESCRIPTION
## Summary
This PR adds shell completion support for both Bash and Zsh.

## Changes
- Add Bash completion script (`completions/has.bash`)
- Add Zsh completion script (`completions/_has`)
- Update Makefile with `install-completions` and `uninstall-completions` targets
- Update README with installation instructions for completions

## Usage
After installation, users will get tab-completion for:
- Options (`-q`, `-h`, `--help`, `-v`, `--version`, `--color-*`)
- Command names available on the system

Closes #65