### PR TITLE
fix: stopped bzip2 from hanging

### DIFF
--- a/has
+++ b/has
@@ -91,7 +91,7 @@ _set_color() {
 __dynamic_detect(){
   cmd="${1}"
   params="${2}"
-  version=$( eval "${cmd}" "${params}" "2>&1" | grep -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
+  version=$( eval "${cmd}" "${params}" "2>&1" </dev/null | grep -a -Eo "${REGEX_SIMPLE_VERSION}" | head -1)
   status=$?
 }
 


### PR DESCRIPTION
**tldr**: newer versions of bzip2 introduce a bug with `bzip2 --version` that causes `has bzip2` to hang.

## Reproduce the issue

Running any of:

- `has bzip2`
- `bzip2 --version 2>&1 | grep -Eo "([[:digit:]]+\.?){2,3}"`
- `bzip2 --version >/dev/null`
- `bzip2 --version | echo`

In both:

- linux 6.18.9-arch1-2 and bzip 1.0.8-6
- macOS Tahoe 26.3 and bzip 1.0.8 (don't know how to see mac-specific revisions)

## Description of Fix

`</dev/null` closes stdin (prevents bzip2 from waiting for input)

`grep -a` treats binary data as text (without it, grep complains `(standard input): binary file matches`)

**This fix should not break any other programs that has can identify, but I'm not 100% confident on that.** Read on for reassurance as to why it's reasonable to believe that this is a bzip2-specific problem, and why the fix should not negatively impact any well-behaved programs.

## Nature of the Problem

After _hours_ of digging, this is how I finally isolated the problem:

```sh
docker run -it ubuntu:20.04 bash
apt update && apt install bzip2
bzip2 --version 2>&1 >/dev/null
```

The above does _not_ hang, and it has bzip 1.0.8-2 (as opposed to 1.0.8-6 in my host Nyarch system).

I never could have solved this without the help of an Agent, and here's its explanation:

> After printing `--version` to stderr, newer bzip2 (1.0.8-3 through 1.0.8-6) **continues executing** and checks:
> - "Is stdout a terminal?"
> - If NO → proceed with normal compression (wait for stdin)
> - If YES → print the warning and exit
> This is the check that produces the message:
> `bzip2: I won't write compressed data to a terminal.`

According to Agent:

> This is broken behavior from bzip2. The `--version` flag should cause it to print version info and exit, not continue with its normal compression operation. The fix with `</dev/null` is a good workaround for this bzip2 bug.

That's as far down the rabbit hole as I'm willing to go. I doubt I would understand the code change to bzip2 even if I could identify the specific revision that introduced the new behavior.

Nor do I have the faintest idea about how to submit a fix for this for bzip2, but this PR would at least prevent `has` from hanging in case any programs made the same mistake in the future. And, if my understanding of it is correct and the Agent is to be believed, closing stdin should not break any other programs with `has`, and enabling `grep` to discard binary data should make it more resilient as well.

Thanks for coming to my TED Talk.