### PR TITLE
feat: added "just" as supported program

### DIFF
--- a/has
+++ b/has
@@ -202,6 +202,7 @@ __detect(){
     g++|clang|ccache)       __dynamic_detect--version "${command}" ;;
     ninja)                  __dynamic_detect--version "${command}" ;;
     act)                    __dynamic_detect--version "${command}" ;;
+    just)                   __dynamic_detect--version "${command}" ;;
 
     ## Ruby
     ruby|gem|rake|bundle)        __dynamic_detect--version "${command}" ;;

--- a/has
+++ b/has
@@ -197,12 +197,13 @@ __detect(){
 
 
     ## Build and Compile
-    gcc|make|cmake|bats)    __dynamic_detect--version "${command}" ;;
+    gcc|make|cmake)         __dynamic_detect--version "${command}" ;;
     shellcheck)             __dynamic_detect--version "${command}" ;;
     g++|clang|ccache)       __dynamic_detect--version "${command}" ;;
     ninja)                  __dynamic_detect--version "${command}" ;;
     act)                    __dynamic_detect--version "${command}" ;;
     just)                   __dynamic_detect--version "${command}" ;;
+    bats)                   __dynamic_detect--version "${command}" ;;
 
     ## Ruby
     ruby|gem|rake|bundle)        __dynamic_detect--version "${command}" ;;

--- a/tests/to-fix/containers/alpine.Dockerfile
+++ b/tests/to-fix/containers/alpine.Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
         gradle~=5.6.4 \
         hugo~=0.61.0 \
         jq=~1.6 \
+        just=~1.5 \
         make~=4.2.1 \
         maven~=3.6.3 `# mvn=3.6.3` \
         mercurial~=5.3.2 `# hg=5.3.2` \

--- a/tests/to-fix/containers/ubuntu.Dockerfile
+++ b/tests/to-fix/containers/ubuntu.Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install --no-inst
         httpie=0.9.8* `# http=0.9.8` \
         hugo=0.40.1* \
         jq=1.5* \
+        just=1.5* \
         leiningen=2.8.1* `# lein=2.8.1` \
         locales `# required for brew` \
         make=4.1* \


### PR DESCRIPTION
[just](https://just.systems) is a modern alternative to make, written in Rust.

> `just` should run on any system with a reasonable `sh`, including Linux, MacOS, and the BSDs.

But not meant to be a direct replacement.

> just is a command runner, not a build system, so it avoids much of make's complexity and idiosyncrasies. No need for `.PHONY` recipes!

see [its repos](https://github.com/casey/just) for details

I have no idea if I did the dockerfile changes correctly. Frankly `make docker-test` doesn't seem to work even on the master branch, but maybe I'm doing something wrong.

(Moving `bats` to its own line is unrelated, just frankly because it doesn't make sense to put it with gcc, make, and cmake; it's not even really a "Build and Compile" program, it's for testing, but at the very least I think putting it on its own line makes most sense.)

