### PR TITLE
fix: failing unit test assumes dev has `bc` installed

### DIFF
--- a/tests/unit/unit-tests.bats
+++ b/tests/unit/unit-tests.bats
@@ -210,7 +210,7 @@ teardown() {
 }
 
 @test "status code in quiet mode still equal to number of failed commands" {
-  HAS_ALLOW_UNSAFE=y run $has -q foobar bc git barbaz
+  HAS_ALLOW_UNSAFE=y run $has -q foobar ls git barbaz
 
   [ "$status" -eq 2 ]
   [ -z "${output}" ]


### PR DESCRIPTION
`bc` is not installed by all systems by default.

I chose `ls` because it is part of `coreutils` which is included in nearly every system - even Windows (Git Bash, Cygwin, and WSL).

The only systems I know of that don't include `ls` are things like Busybox systems. If you're trying to develop `has` on a Busybox system.....  ¯\\_(ツ)_/¯


## To reproduce

1. Check out the state of a master
2. Try to send a Unicode emoji (e.g. `bats tests/unit/unit-tests.bats`) to get them to calm down