### PR TITLE
Make HAS_ALLOW_UNSAFE case insensitive (closes #35)

### DIFF
--- a/has
+++ b/has
@@ -315,7 +315,7 @@ __detect(){
 
     *)
       ## Can allow dynamic checking here, i.e. checking commands that are not listed above
-      if [[ "${HAS_ALLOW_UNSAFE}" == "y" ]]; then
+      if [[ "${HAS_ALLOW_UNSAFE}" == [Yy] || "${HAS_ALLOW_UNSAFE}" == [Yy][Ee][Ss] ]]; then
         __dynamic_detect--version "${command}"
         ## fallback checking based on status!=127 (127 means command not found)
         ## TODO can check other type of supported version-checks if status was not 127

--- a/tests/unit/unit-tests.bats
+++ b/tests/unit/unit-tests.bats
@@ -107,6 +107,15 @@ teardown() {
   [ "$(echo "${output}" | grep ${fancyx} | grep "foobar")" ]
 }
 
+@test "env var 'HAS_ALLOW_UNSAFE' is case insensitive" {
+  for value in Y yes Yes YES; do
+    HAS_ALLOW_UNSAFE=$value run $has foobar
+
+    [ "$status" -eq 1 ]
+    [ -z "$(echo "${output}" | grep "foobar not understood")" ]
+  done
+}
+
 @test "status code reflects number of failed commands" {
   HAS_ALLOW_UNSAFE=y run $has foobar git barbaz
 


### PR DESCRIPTION
## What

Closes #35.

`HAS_ALLOW_UNSAFE` was only honored when set to the exact lowercase `y`, so common truthy spellings (`Y`, `yes`, `YES`) were silently ignored and the dynamic/unsafe check never ran. This matches the maintainer's +1 for case-insensitivity in the issue thread.

## Fix

The guard now accepts `y`/`Y` and `yes` (any case) via glob patterns in `[[ ]]`:

```sh
if [[ "${HAS_ALLOW_UNSAFE}" == [Yy] || "${HAS_ALLOW_UNSAFE}" == [Yy][Ee][Ss] ]]; then
```

Glob patterns keep this bash 3.2-safe (macOS) — no `${var,,}`. No breaking change: `HAS_ALLOW_UNSAFE=N`/empty/anything else still disables the unsafe path exactly as before.

## Tests

Added a unit test asserting `Y`, `yes`, `Yes`, `YES` all enable the unsafe path (output no longer contains `foobar not understood`).

## Validation

```
$ bats tests/unit/unit-tests.bats
ok 5 env var 'HAS_ALLOW_UNSAFE' is case insensitive
...
$ shellcheck has   # clean, exit 0
```

Verified genuine RED→GREEN: reverting only the source guard back to `== "y"` turns the new test red (`foobar not understood` reappears for `Y`/`yes`/…); restoring the fix makes it green.

Note: two tests (`testing coreutils commands`, `status code in quiet mode still equal to number of failed commands`) fail on a clean `master` checkout on my machine too — they are pre-existing and outside this diff (which touches only the `HAS_ALLOW_UNSAFE` guard + one new test).

Happy to adjust (e.g. narrow to just `[Yy]` if you'd rather not accept `yes`).
